### PR TITLE
✨ feat: 롤리별 스티커 데이터 조회 구현

### DIFF
--- a/app/(anon)/rollies/[id]/page.tsx
+++ b/app/(anon)/rollies/[id]/page.tsx
@@ -10,7 +10,8 @@ import HomeButton from "@/components/homeButton/HomeButton";
 import CreateStickerButton from "@/components/createStickerButton/CreateStickerButton";
 import Rolly from "@/components/rolly/Rolly";
 import MainButton from "@/components/mainButton/MainButton";
-import { Postit } from "@/components/rolly/Rolly.type";
+import { PostitDto } from "@/application/usecases/postit/dto/PostitDto";
+import { StickerDto } from "@/application/usecases/sticker/dto/StickerDto";
 import useToggle from "@/hooks/useToggle";
 import Modal from "@/components/modal/Modal";
 import supabase from "@/utils/supabase/supabaseClient";
@@ -21,7 +22,8 @@ const Rollies = () => {
   const router = useRouter();
   const { id: rollyId } = useParams();
   const { title, image, phrase, rollyTheme, setRollyData } = useRollyStore();
-  const [postits, setPostits] = useState<Postit[]>([]);
+  const [postits, setPostits] = useState<PostitDto[]>([]);
+  const [stickers, setStickers] = useState<StickerDto[]>([]);
   const [isLocked, setIsLocekd] = useState(false);
   const { userId } = useUserStore();
   const [isConfirmModalOpen, toggleConfirmModal] = useToggle(false);
@@ -54,8 +56,17 @@ const Rollies = () => {
       }
     };
 
+    const fetcStickers = async () => {
+      const response = await fetch(`/api/stickers?rollyId=${rollyId}`);
+      const { success, stickersDto } = await response.json();
+      if (success) {
+        setStickers(stickersDto);
+      }
+    };
+
     fetchRollyDetail();
     fetchPostits();
+    fetcStickers();
   }, [rollyId, setRollyData]);
 
   const navigateToPostIt = () => {
@@ -127,6 +138,7 @@ const Rollies = () => {
           isEditable={false}
           imageUrl={image}
           postits={postits}
+          stickers={stickers}
         />
       </div>
       {!isLocked && <CreateStickerButton onClick={navigateToCreateSticker} />}

--- a/app/api/stickers/route.ts
+++ b/app/api/stickers/route.ts
@@ -1,0 +1,47 @@
+import { DfStickersUsecase } from "@/application/usecases/sticker/DfStickersUsecase";
+import { StickerDto } from "@/application/usecases/sticker/dto/StickerDto";
+import { DfStickerStyleListUsecase } from "@/application/usecases/stickerStyle/DfStickerStyleListUsecase";
+import { StickerStyleDto } from "@/application/usecases/stickerStyle/dto/StickerStyleDto";
+import { StickerRepository } from "@/domain/repositories/StickerRepository";
+import { StickerStyleRepository } from "@/domain/repositories/StickerStyleRepository";
+import { SbStickerRepository } from "@/infrastructure/repositories/SbStickerRepository";
+import { SbStickerStyleRepository } from "@/infrastructure/repositories/SbStickerStyleRepository";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const rollyId = Number(url.searchParams.get("rollyId"));
+
+    if (isNaN(rollyId)) {
+      return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    }
+
+    const stickerStyleRepository: StickerStyleRepository =
+      new SbStickerStyleRepository();
+    const stickerStyleListUsecase: DfStickerStyleListUsecase =
+      new DfStickerStyleListUsecase(stickerStyleRepository);
+    const stickerStyleList: StickerStyleDto[] =
+      await stickerStyleListUsecase.execute();
+
+    if (!stickerStyleList) {
+      throw new Error("stickerStyleList가 없습니다.");
+    }
+
+    const repository: StickerRepository = new SbStickerRepository();
+    const sitckersUsecase: DfStickersUsecase = new DfStickersUsecase(
+      repository
+    );
+    const stickersDto: StickerDto[] = await sitckersUsecase.execute(
+      rollyId,
+      stickerStyleList
+    );
+
+    return NextResponse.json({ success: true, stickersDto }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: (error as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/member/rollies/[id]/page.tsx
+++ b/app/member/rollies/[id]/page.tsx
@@ -9,14 +9,17 @@ import BackButton from "@/components/backButton/BackButton";
 import CreateStickerButton from "@/components/createStickerButton/CreateStickerButton";
 import Rolly from "@/components/rolly/Rolly";
 import MainButton from "@/components/mainButton/MainButton";
-import { Postit } from "@/components/rolly/Rolly.type";
 import ImageDownloadButton from "@/components/imageDownloadButton/ImageDownloadButton";
+
+import { PostitDto } from "@/application/usecases/postit/dto/PostitDto";
+import { StickerDto } from "@/application/usecases/sticker/dto/StickerDto";
 
 const Rollies = () => {
   const router = useRouter();
   const { id: rollyId } = useParams();
   const { title, image, phrase, rollyTheme, setRollyData } = useRollyStore();
-  const [postits, setPostits] = useState<Postit[]>([]);
+  const [postits, setPostits] = useState<PostitDto[]>([]);
+  const [stickers, setStickers] = useState<StickerDto[]>([]);
   const [isLocked, setIsLocekd] = useState(false);
   const rollyRef = useRef<HTMLDivElement>(null);
 
@@ -45,8 +48,17 @@ const Rollies = () => {
       }
     };
 
+    const fetcStickers = async () => {
+      const response = await fetch(`/api/stickers?rollyId=${rollyId}`);
+      const { success, stickersDto } = await response.json();
+      if (success) {
+        setStickers(stickersDto);
+      }
+    };
+
     fetchRollyDetail();
     fetchPostits();
+    fetcStickers();
   }, [rollyId, setRollyData]);
 
   const navigateToPostIt = () => {
@@ -75,6 +87,7 @@ const Rollies = () => {
           isEditable={false}
           imageUrl={image}
           postits={postits}
+          stickers={stickers}
         />
       </div>
       {!isLocked && <CreateStickerButton onClick={navigateToCreateSticker} />}

--- a/application/usecases/sticker/DfStickersUsecase.ts
+++ b/application/usecases/sticker/DfStickersUsecase.ts
@@ -1,0 +1,19 @@
+import { StickerRepository } from "@/domain/repositories/StickerRepository";
+import { StickerDto } from "./dto/StickerDto";
+
+export class DfStickersUsecase {
+  constructor(private repository: StickerRepository) {}
+
+  async execute(
+    rollyId: number,
+    stickerStyleList: { id: number; name: string }[]
+  ): Promise<StickerDto[]> {
+    const stickers = await this.repository.findStickers(rollyId);
+
+    return stickers.map((sticker) => ({
+      stickerStyle: `/images/sticker/${stickerStyleList[sticker.stickerStyleId - 1]?.name + ".svg" || "default.svg"}`,
+      xPosition: sticker.xPosition,
+      yPosition: sticker.yPosition,
+    }));
+  }
+}

--- a/application/usecases/sticker/dto/StickerDto.ts
+++ b/application/usecases/sticker/dto/StickerDto.ts
@@ -1,0 +1,5 @@
+export interface StickerDto {
+  stickerStyle: string;
+  xPosition: number;
+  yPosition: number;
+}

--- a/components/rolly/Rolly.tsx
+++ b/components/rolly/Rolly.tsx
@@ -9,9 +9,9 @@ const Rolly = ({
   previewImgUrl,
   imageUrl,
   postits = [],
+  stickers = [],
   onFileChange,
   onPhraseClick,
-  children,
 }: RollyProps) => {
   return (
     <div className={`${styles["rolly"]} ${styles[theme]}`}>
@@ -66,6 +66,7 @@ const Rolly = ({
               src={imageUrl || "default.svg"}
               width={100}
               height={100}
+              className={styles["img"]}
               alt="업로드한 이미지"
             />
           )}
@@ -88,7 +89,21 @@ const Rolly = ({
           </div>
         ))}
       </div>
-      {children}
+      {stickers.map((sticker, index) => (
+        <Image
+          src={sticker.stickerStyle}
+          key={index}
+          width={50}
+          height={50}
+          alt={`스티커 ${sticker.stickerStyle}`}
+          style={{
+            position: "absolute",
+            top: `${sticker.yPosition}px`,
+            left: `${sticker.xPosition}%`,
+            zIndex: 999,
+          }}
+        />
+      ))}
     </div>
   );
 };

--- a/components/rolly/Rolly.type.ts
+++ b/components/rolly/Rolly.type.ts
@@ -1,7 +1,13 @@
-export type Postit = {
+type Postit = {
   content: string;
   fontFamily: string;
   postitTheme: string;
+};
+
+type Sticker = {
+  stickerStyle: string;
+  xPosition: number;
+  yPosition: number;
 };
 
 export type RollyProps = {
@@ -11,6 +17,7 @@ export type RollyProps = {
   previewImgUrl?: string | null;
   imageUrl?: string;
   postits?: Postit[];
+  stickers?: Sticker[];
   children?: React.ReactNode;
   onPhraseClick?: () => void;
   onFileChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;

--- a/domain/entities/Sticker.ts
+++ b/domain/entities/Sticker.ts
@@ -1,0 +1,10 @@
+export interface Sticker {
+  id: number;
+  rollyId: number;
+  stickerStyleId: number;
+  xPosition: number;
+  yPosition: number;
+  rotation: number;
+  scale: number;
+  createdAt: number;
+}

--- a/domain/repositories/StickerRepository.ts
+++ b/domain/repositories/StickerRepository.ts
@@ -1,0 +1,5 @@
+import { Sticker } from "../entities/Sticker";
+
+export interface StickerRepository {
+  findStickers(rollyId: number): Promise<Sticker[]>;
+}

--- a/infrastructure/repositories/SbStickerRepository.ts
+++ b/infrastructure/repositories/SbStickerRepository.ts
@@ -1,0 +1,38 @@
+import { Sticker } from "@/domain/entities/Sticker";
+import { StickerRepository } from "@/domain/repositories/StickerRepository";
+import supabase from "@/utils/supabase/supabaseClient";
+
+export class SbStickerRepository implements StickerRepository {
+  async findStickers(rollyId: number): Promise<Sticker[]> {
+    try {
+      const { data, error } = await supabase
+        .from("sticker")
+        .select("*")
+        .eq("rolly_id", rollyId);
+
+      if (error) throw error;
+      if (!data) throw new Error("sticker들을 가져오지 못했습니다.");
+
+      return data.map(
+        ({
+          rolly_id: rollyId,
+          sticker_style_id: stickerStyleId,
+          x_position: xPosition,
+          y_position: yPosition,
+          created_at: createdAt,
+          ...rest
+        }) => ({
+          rollyId,
+          stickerStyleId,
+          xPosition,
+          yPosition,
+          createdAt,
+          ...rest,
+        })
+      );
+    } catch (error) {
+      console.error("sticker들 가져오기 실패:", (error as Error).message);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
롤리 페이지 포스트잇 데이터 조회 클린 아키텍처 적용

- Entities
    - domain/entities/Sticker.ts
    - domain/repositories/StickerRepository.ts : findStickers
- Usecases
    - application/usecases/rolly/DfStickersUsecase.ts
    - apllication/usecases/rolly/dto/StickerDto.ts
- Adapters
    - app/api/stickers/route.ts : GET
- DB
    - infrastructure/repositories/SbStickerRepository.ts