### PR TITLE
🐛 fix: 배포 전 여러 버그 픽스

### DIFF
--- a/app/(anon)/postits/create/page.module.scss
+++ b/app/(anon)/postits/create/page.module.scss
@@ -6,10 +6,10 @@
 .textArea {
   position: absolute;
   top: 30px;
-  left: 0;
-  width: 100%;
+  left: 22%;
+  width: 60%;
+  margin-top: 24%;
   border: none;
-  padding: 25%;
   background: transparent;
   color: var(--color-gray-1);
   font-size: var(--font-size-md);

--- a/app/(anon)/postits/create/page.tsx
+++ b/app/(anon)/postits/create/page.tsx
@@ -134,7 +134,7 @@ const CreatePostits = () => {
       });
 
       togglePostitModal();
-      router.push(`/(anon)/rollies/${rollyId}`);
+      router.replace(`/(anon)/rollies/${rollyId}`);
     } catch (error) {
       console.log(error);
     }

--- a/app/member/postits/create/page.module.scss
+++ b/app/member/postits/create/page.module.scss
@@ -6,10 +6,10 @@
 .textArea {
   position: absolute;
   top: 30px;
-  left: 0;
-  width: 100%;
+  left: 22%;
+  width: 60%;
+  margin-top: 24%;
   border: none;
-  padding: 25%;
   background: transparent;
   color: var(--color-gray-1);
   font-size: var(--font-size-md);

--- a/app/member/postits/create/page.tsx
+++ b/app/member/postits/create/page.tsx
@@ -134,7 +134,7 @@ const CreatePostits = () => {
       });
 
       togglePostitModal();
-      router.push(`/member/rollies/${rollyId}`);
+      router.replace(`/member/rollies/${rollyId}`);
     } catch (error) {
       console.log(error);
     }

--- a/app/member/rollies/create/page.tsx
+++ b/app/member/rollies/create/page.tsx
@@ -116,7 +116,7 @@ const CreateRollies = () => {
       });
       const { rollyId } = await response.json();
       toggleCreateModal();
-      router.push(`/member/rollies/${rollyId}`);
+      router.replace(`/member/rollies/${rollyId}`);
     } catch (error) {
       console.log(error);
     }

--- a/app/member/rollies/created/page.tsx
+++ b/app/member/rollies/created/page.tsx
@@ -5,14 +5,19 @@ import CreateRollyButton from "@/components/createRollyButton/CreateRollyButton"
 import Header from "@/components/header/Header";
 import RollyItem from "@/components/rollyItem/RollyItem";
 import styles from "./page.module.scss";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CreatedRollyDto } from "@/application/usecases/rolly/dto/CreatedRollyDto";
 import useUserStore from "@/application/state/useUserStore";
+import useToggle from "@/hooks/useToggle";
+import Modal from "@/components/modal/Modal";
+import useRollyCreateStore from "@/application/state/useRollyCreateStore";
+import { InputFormData } from "@/components/modal/Modal.type";
 
 const CreatedRollies: React.FC = () => {
   const [rollyItems, setRollyItems] = useState<CreatedRollyDto[]>([]);
+  const [isCreateRollyModalOpen, toggleCreateRollyModal] = useToggle(false);
+  const { setType, setTitle } = useRollyCreateStore();
   const { userId } = useUserStore();
   const router = useRouter();
 
@@ -25,6 +30,27 @@ const CreatedRollies: React.FC = () => {
     };
     fetchCreatedRollies();
   }, [userId]);
+
+  const handleConfirm = (inputFormData?: InputFormData) => {
+    if (
+      inputFormData &&
+      inputFormData.modal_radio &&
+      inputFormData.modal_text
+    ) {
+      switch (inputFormData.modal_radio) {
+        case "개인용":
+          setType(1);
+          break;
+        case "단체용":
+          setType(2);
+          break;
+        default:
+          break;
+      }
+      setTitle(inputFormData.modal_text);
+    }
+    router.push("/member/rollies/create");
+  };
 
   const handleItemClick = (id: number) => {
     router.push(`/member/rollies/${id}`);
@@ -53,9 +79,10 @@ const CreatedRollies: React.FC = () => {
         <Header leftContent={<BackButton />} title="내가 만든 롤리" />
       </div>
       <div className={styles["create-rolly-button"]}>
-        <Link href={"/member/rollies/create/"}>
-          <CreateRollyButton />
-        </Link>
+        <CreateRollyButton
+          onClick={toggleCreateRollyModal}
+          className={styles["create-rolly-btn"]}
+        />
       </div>
       <p className={styles["list-title"]}>롤리 리스트</p>
       <div className={styles["list"]}>
@@ -73,6 +100,25 @@ const CreatedRollies: React.FC = () => {
           />
         ))}
       </div>
+      <Modal
+        contents={[
+          {
+            title: "롤리의 타입을 선택해주세요",
+            body: "개인용은 받는 사람이 답장할 수 있어요!",
+            input: "radio",
+            radioOptions: ["개인용", "단체용"],
+          },
+          {
+            title: "롤리의 이름을 작성해주세요",
+            body: "최대 12자까지 가능해요!",
+            input: "text",
+            maxLength: 12,
+          },
+        ]}
+        onConfirm={handleConfirm}
+        onCancel={toggleCreateRollyModal}
+        isOpen={isCreateRollyModalOpen}
+      />
     </div>
   );
 };

--- a/components/rollyItem/RollyItem.tsx
+++ b/components/rollyItem/RollyItem.tsx
@@ -87,8 +87,7 @@ const RollyItem: React.FC<RollyItemProps> = ({
       </div>
       <div className={styles["wrapper"]}>
         <p className={styles["date"]}>{date}</p>
-        {/* delete 버튼: isCreated가 true이면 항상 유지 */}
-        {isCreated ? (
+        {isCreated && !isLocked ? (
           <button
             className={classNames("action", styles.action)}
             onClick={toggleDeleteModal}
@@ -101,6 +100,7 @@ const RollyItem: React.FC<RollyItemProps> = ({
             />
           </button>
         ) : (
+          !isLocked &&
           onReply && (
             <button
               className={classNames("action", styles.action)}
@@ -121,7 +121,7 @@ const RollyItem: React.FC<RollyItemProps> = ({
         contents={[
           {
             title: "롤리를 완성하시겠어요?",
-            body: "완성 후에는 메세지를 작성할 수 없어요!",
+            body: "완성 후에는 메세지 작성 및 롤리 삭제가 불가해요!",
           },
         ]}
         confirmText={"완성"}

--- a/components/rollyItem/RollyItem.tsx
+++ b/components/rollyItem/RollyItem.tsx
@@ -100,7 +100,7 @@ const RollyItem: React.FC<RollyItemProps> = ({
             />
           </button>
         ) : (
-          !isLocked &&
+          isLocked &&
           onReply && (
             <button
               className={classNames("action", styles.action)}

--- a/components/rollyItem/RollyItem.tsx
+++ b/components/rollyItem/RollyItem.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import styles from "./RollyItem.module.scss";
 import useToggle from "@/hooks/useToggle";
 import Modal from "../modal/Modal";
@@ -70,7 +71,10 @@ const RollyItem: React.FC<RollyItemProps> = ({
         <p className={styles["title"]}>{title}</p>
         {/* lock 버튼: isCreated가 true일 때만 표시하고, isLocked 상태가 되면 안 보이도록 */}
         {isCreated && !isLocked && (
-          <button className={styles["lock"]} onClick={toggleLockModal}>
+          <button
+            className={classNames("lock", styles.lock)}
+            onClick={toggleLockModal}
+          >
             <Image
               src="/icons/lock.svg"
               width={24}
@@ -85,7 +89,10 @@ const RollyItem: React.FC<RollyItemProps> = ({
         <p className={styles["date"]}>{date}</p>
         {/* delete 버튼: isCreated가 true이면 항상 유지 */}
         {isCreated ? (
-          <button className={styles["action"]} onClick={toggleDeleteModal}>
+          <button
+            className={classNames("action", styles.action)}
+            onClick={toggleDeleteModal}
+          >
             <Image
               src="/icons/delete.svg"
               width={24}
@@ -95,7 +102,10 @@ const RollyItem: React.FC<RollyItemProps> = ({
           </button>
         ) : (
           onReply && (
-            <button className={styles["action"]} onClick={onReply}>
+            <button
+              className={classNames("action", styles.action)}
+              onClick={onReply}
+            >
               <Image
                 src="/icons/reply.svg"
                 width={24}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/supabase-js": "latest",
         "autoprefixer": "10.4.20",
         "class-variance-authority": "^0.7.0",
+        "classnames": "^2.5.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",
         "next": "latest",
@@ -5193,6 +5194,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clean-webpack-plugin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-4.0.0.tgz",
@@ -8234,15 +8241,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
-    },
-    "node_modules/nodemailer": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
-      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "next": "latest",
         "next-pwa": "^5.6.0",
         "next-themes": "^0.4.3",
+        "nodemailer": "^6.10.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "sass": "^1.83.4",
@@ -8241,6 +8242,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "latest",
     "next-pwa": "^5.6.0",
     "next-themes": "^0.4.3",
+    "nodemailer": "^6.10.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "sass": "^1.83.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@supabase/supabase-js": "latest",
     "autoprefixer": "10.4.20",
     "class-variance-authority": "^0.7.0",
+    "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",
     "next": "latest",


### PR DESCRIPTION
## Description
- 전역 클래스(lock, action)을 유지하면서, CSS 모듈도 적용
- BackButton 클릭 시 이전 페이지가 create 페이지면 이동 제한
- 포스트잇 작성할 때 텍스트가 포스트잇 이미지 밖으로 노출되지 않게 수정
- 만든 롤리함에서 롤리 만들기 버튼 클릭스 모달 띄우기
- 만든 롤리함에서 잠금 후엔 잠금 버튼과 삭제 버튼 같이 사라지게 수정, 모달에 작성 및 삭제 불가하다 작성